### PR TITLE
Add copyright attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Gopher 3D model
 
 <img width="50%" src="https://raw.github.com/golang-samples/gopher-3d/master/gopher3d.png"/>
 
+The Go gopher was designed by Renee French. (http://reneefrench.blogspot.com/)
+The gopher 3D model was made by Takuya Ueda (http://u.hinoichi.net).
+Licensed under the Creative Commons 3.0 Attributions license.
+
 <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.ja">
     <img alt="Creative Commons licensing" style="border-width:0" src="http://i.creativecommons.org/l/by/3.0/88x31.png" />
 </a>


### PR DESCRIPTION
The Go gopher is licensed under the CC attribution license, which allows sharing and adapting the work as long as credit is given to the original author. This change adds the original creator's name to the README.

(Found while I was hoping to use the model in a demo.)
